### PR TITLE
Remove "-ansi -pedantic" as default GCC options.  Work-around Long.cp…

### DIFF
--- a/activemq-cpp/configure.ac
+++ b/activemq-cpp/configure.ac
@@ -224,7 +224,7 @@ case "${host_os}" in
 esac
 
 if test "$GCC" = "yes"; then
-   PLAT_CXXFLAGS="-ansi -pedantic"
+   PLAT_CXXFLAGS=""
 fi
 
 ## find and configure the Apache Decaf Library

--- a/activemq-cpp/src/main/decaf/lang/Long.cpp
+++ b/activemq-cpp/src/main/decaf/lang/Long.cpp
@@ -19,6 +19,12 @@
 #include <decaf/lang/Character.h>
 #include <sstream>
 
+// OPT-NOTE
+// Disable optimization for this code.  When enabled, the overflow check fails to work correctly
+//  when parsing strings into longs.
+#pragma GCC push_options
+#pragma GCC optimize("O0")
+
 using namespace decaf;
 using namespace decaf::lang;
 
@@ -210,6 +216,8 @@ long long Long::parse(const String& value, int offset, int radix, bool negative)
                 "Long::parseLong - String contains no digit characters.");
         }
 
+        // OPT-NOTE
+        // This is the test that ends up failing when optimization is enabled.
         if (max > result) {
             throw exceptions::NumberFormatException(__FILE__, __LINE__,
                 "Long::parseLong - Parsed value greater than max for radix.");
@@ -465,3 +473,5 @@ Long Long::valueOf(const String& value) {
 Long Long::valueOf(const String& value, int radix) {
     return Long(Long::parseLong(value, radix));
 }
+
+#pragma GCC pop_options

--- a/activemq-cpp/src/test/decaf/util/DateTest.cpp
+++ b/activemq-cpp/src/test/decaf/util/DateTest.cpp
@@ -19,6 +19,7 @@
 
 #include <decaf/util/Date.h>
 #include <decaf/lang/Thread.h>
+#include <stdlib.h>
 
 using namespace std;
 using namespace decaf;
@@ -59,8 +60,9 @@ void DateTest::test() {
 ////////////////////////////////////////////////////////////////////////////////
 void DateTest::testToString() {
 
+    setenv("TZ", "EST", 1);
     Date now(1443038174960LL);
     CPPUNIT_ASSERT(now.toString() != "");
     CPPUNIT_ASSERT(now.toString().size() >= 20);
-    CPPUNIT_ASSERT_EQUAL(std::string("Wed Sep 23 15:56:14 EDT 2015"), now.toString());
+    CPPUNIT_ASSERT_EQUAL(std::string("Wed Sep 23 14:56:14 EST 2015"), now.toString());
 }


### PR DESCRIPTION
…p bug when optimized.  Date test less fragile - force expected TZ used by test.

- The "-ansi -pedantic" options force a really old standard of C/C++ to be used
- The Long.cpp bug causes overflow detection to fail, leading to missing NumberFormatExceptions
- The Date test was always timezone-specific, making it fragile to run anywhere outside that timezone (EDT)